### PR TITLE
Merge changes from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Now create the following 4 secrets. Use the credentials generated in the above s
 |zulip_organization_url       | URL of your Zulip organization.              |
 |zulip_bot_email              | The email of the Zulip bot you created       |
 |zulip_bot_key                | API key of the Zulip bot you created         |
-|github_personal_access_token | The GitHub personal access token you created |
+|gh_personal_access_token     | The GitHub personal access token you created |
 
 
 ### Step 4 - Configure the streams you want to index
@@ -105,7 +105,7 @@ jobs:
         zulip_organization_url: ${{ secrets.zulip_organization_url }}
         zulip_bot_email: ${{ secrets.zulip_bot_email }}
         zulip_bot_key: ${{ secrets.zulip_bot_key }}
-        github_personal_access_token: ${{ secrets.github_personal_access_token }}
+        github_personal_access_token: ${{ secrets.gh_personal_access_token }}
 ```
 
 The above file tells GitHub to run the `zulip-archive` action every 20 minutes. You can adjust the `cron` key to modify the schedule as you feel appropriate. If you Zulip organization history is very large (not the case for most users) we recommend to increase the cron period from running every 30 minutes to maybe run every 1 hour (eg `'0 * * * *'`). This is is because the initial archive run that fetches the messages for the first time takes a lot of time and we don't want the second cron job to start before finishing the first run is over. After the initial run is over you can shorten the cron job period if necessary.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,18 @@ jobs:
         zulip_bot_email: ${{ secrets.zulip_bot_email }}
         zulip_bot_key: ${{ secrets.zulip_bot_key }}
         github_personal_access_token: ${{ secrets.gh_personal_access_token }}
+        delete_history: true
 ```
 
 The above file tells GitHub to run the `zulip-archive` action every 20 minutes. You can adjust the `cron` key to modify the schedule as you feel appropriate. If you Zulip organization history is very large (not the case for most users) we recommend to increase the cron period from running every 30 minutes to maybe run every 1 hour (eg `'0 * * * *'`). This is is because the initial archive run that fetches the messages for the first time takes a lot of time and we don't want the second cron job to start before finishing the first run is over. After the initial run is over you can shorten the cron job period if necessary.
+
+If you are running frequent updates with a busy Zulip organization,
+the Git repository that you use to run the action will grow very
+quickly. We recommend setting the `delete_history` option to
+`true`. This will overwrite the git history in the repository (but
+keep all the content). If you are using the repository for more than
+just the Zulip archive, you may want to set this to `false`, but be
+warned that the repository size may explode.
 
 ### Step 6 - Verify everything works
 

--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,4 @@ runs:
     - ${{ inputs.zulip_bot_email }}
     - ${{ inputs.zulip_bot_key }}
     - ${{ inputs.github_personal_access_token }}
+    - ${{ inputs.delete_history }}


### PR DESCRIPTION
This just pulls in the whitespace fixes applied in https://github.com/zulip/zulip-archive/pull/39 (and the commit before it), with the intent of making it clearer how this repo relates to upstream (answer: it is identical to eb1605d1557c6650cce7f2dc0dad95aca257658a other than containing a change to the pip installer) 